### PR TITLE
Runscript for starting the notebook server

### DIFF
--- a/gromacs-notebook.deffile
+++ b/gromacs-notebook.deffile
@@ -2,3 +2,11 @@ Bootstrap: docker
 Registry: http://localhost:5000
 Namespace:
 From:gmxapi-notebook:puhti
+
+%setup
+    mkdir -p $SINGULARITY_ROOTFS/opt/bin/
+    cp start-jupyter-server $SINGULARITY_ROOTFS/opt/bin/
+    chmod a+xr $SINGULARITY_ROOTFS/opt/bin/start-jupyter-server
+
+%runscript
+    exec /opt/bin/start-jupyter-server

--- a/start-jupyter-server
+++ b/start-jupyter-server
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Start a Jupyter notebook server and write out instructions
+# for ssh port forwarding
+# Note: it is assumed that the port where notebook server is started
+# is available in the local machine
+
+# Make sure script is run within a slurm job
+if [ -z "$SLURM_JOB_ID" ]
+then
+    echo "Jupyter notebook server can be started only in compute nodes"
+    echo "Execute ${0##*/} in interactive session or in batch job script"
+    echo "See docs.csc.fi/... for more details"
+    exit 1
+fi
+
+
+# Check for Jupyter
+if ! [ -x "$(command -v jupyter)" ]; then
+  echo "Jupyter is not available"
+  echo "Please load a module including Jupyter environment such as"
+  echo "python-env, python-data, tensorflow, ..."
+  exit 1
+fi
+
+# set an env variable, find hostname of compute node
+XDG_RUNTIME_DIR=""
+NODENAME=$(hostname)
+
+
+#start notebook server and redirect stderr
+jupyter notebook --no-browser 2> jupyter.$SLURM_JOB_ID.out &
+pid=$!
+
+# find url with token and port for ssh forwarding
+# the while loop ensures that the server has been started
+url=""
+while [ -z "$url" ]
+do
+    sleep 3
+    url=`jupyter notebook list | sed -n 's/\(http.*\) ::.*/\1/p'`
+done
+port=`echo $url | sed -e 's/.*host:\([0-9]*\).*/\1/'`
+
+# write out tunneling instructions 
+echo -e "
+    Copy/Paste this in your local terminal to ssh tunnel with remote
+    -----------------------------------------------------------------
+    Linux / macOS / MobaXTerm / Cmder:
+    ssh -N -L $port:localhost:$port -J $USER@puhti.csc.fi $USER@$NODENAME
+
+    PuTTy:
+    ssh -N -L $port:localhost:$port $USER@$NODENAME
+    Set Source ($port) and Destination (localhost:$port) in:
+    PuTTy -> Connection -> SSH -> Tunnels
+    -----------------------------------------------------------------
+    "
+
+echo -e "
+    Copy/Paste this URL into your browser
+    -----------------------------------------------------------------
+    $url
+    -----------------------------------------------------------------
+    "
+
+# Trap CTRL-C and wait for the server
+trap "kill -1 $pid" SIGINT
+wait $pid


### PR DESCRIPTION
I added to singularity image the script that prints out the correct ssh forwarding command. If several users run on the same node they will have different ports, jupyter server picks up automatically the next available port and everything should work fine.

The script was made also a runscript, i.e. the notebook server can be started just as:
```
singularity run --bind $PWD:$PWD -B /users/$USER gromacs-notebook-puhti.sif
```
which prints out then ssh command to copy-paste as well as the URL to copy-paste.

In principle, the local port is arbitrary, however, the script here uses the same port as in the remote. If the local port is for some reason already in use, the ssh command fails. 