### PR TITLE
Precaution, in case RDTSCP may not be possible.

### DIFF
--- a/gromacs-notebook.dockerfile
+++ b/gromacs-notebook.dockerfile
@@ -60,6 +60,7 @@ RUN cd gromacs-2021 && \
     cmake .. \
         -DCMAKE_INSTALL_PREFIX=/usr/local/gromacs \
         -DGMX_THREAD_MPI=ON \
+        -DGMX_USE_RDTSCP=OFF \
         -DCMAKE_BUILD_TYPE=$TYPE && \
     make -j$DOCKER_CORES && \
     make -j$DOCKER_CORES install


### PR DESCRIPTION
RDTSCP may not work in containerized versions of otherwise compatible environments.

Unfortunately, GROMACS does not reliably detect this at run time (or perhaps the build and run time environments behave differently). I have encountered problems in Docker containers that build GROMACS without disabling RDTSCP.

I don't know whether this problem occurs in Singularity containers, but adding `-DGMX_USE_RDTSCP=OFF` seems like an appropriate precaution.